### PR TITLE
Changing 'report_code' to 'report' in plumber_pi for scheduler matching

### DIFF
--- a/plumber_api.R
+++ b/plumber_api.R
@@ -30,12 +30,12 @@ function() {
 
 # Endpoint B -------------------------------------------------------------------
 #* Generate report and upload to GCS
-#* @param report_code:string The code of the report as specified in the config
+#* @param report:string The code of the report as specified in the config
 #* @get /render_rmd_report
-function(report_code) {
+function(report) {
   
   # Get the configuration associated with the report code
-  cfg <- report_config %>% filter(code == report_code)
+  cfg <- report_config %>% filter(code == report)
   
   # Generate a unique PDF filename
   date_stamp <- format(Sys.time(), "%m_%d_%Y")


### PR DESCRIPTION
Changing 'report_code' to 'report' in plumber_api for scheduler matching